### PR TITLE
fix callback_url param error when query params are also included

### DIFF
--- a/lib/omniauth/strategies/ecwid.rb
+++ b/lib/omniauth/strategies/ecwid.rb
@@ -18,6 +18,12 @@ module OmniAuth
       uid {
         access_token.params.fetch("store_id")
       }
+
+      # ecwid doesnt like it when the query params are also passed
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
     end
   end
 end


### PR DESCRIPTION
Ecwid seems to have made a change at some point in the recent past whereby they now require the 'redirect_uri' parameter to EXACTLY match what is in their app settings - ie, even having query_string parameters is causing a redirect_uri match failed permission issue when generating the access token.

By default, omniauth takes whatever code url arrives and uses that as the 'redirect_uri' parameter when generating the access_token request. With this PR, we now remove any query_string parameters from the redirect_uri before it goes on to the access_token request. 

This fixed our problems, maybe it will help someone else...
 